### PR TITLE
Extend documentations

### DIFF
--- a/js/error-handling.md
+++ b/js/error-handling.md
@@ -43,7 +43,7 @@ class UserError extends Error {
 }
 ```
 
-#### Pass additional information to the error message
+#### Pass additional, useful information along with the error message
 
 GOOD
 

--- a/js/error-handling.md
+++ b/js/error-handling.md
@@ -25,7 +25,7 @@ BAD
 class ExampleError extends Error {}
 ```
 
-#### Objects need to be serialized in error messages
+#### Serialize objects in error messages
 
 GOOD
 

--- a/js/error-handling.md
+++ b/js/error-handling.md
@@ -25,6 +25,50 @@ BAD
 class ExampleError extends Error {}
 ```
 
+#### Define meaningful error classes
+
+GOOD
+
+```js
+class RecordAlreadyExistsError extends Error {
+  // ...
+}
+```
+
+BAD
+
+```js
+class UserError extends Error {
+  // ...
+}
+```
+
+#### Pass additional information to the error message
+
+GOOD
+
+```js
+class RecordAlreadyExistsError extends Error {
+  // ...
+}
+
+if (userExists(user)) {
+  throw new RecordAlreadyExistsError(user + " already exists.");
+}
+```
+
+BAD
+
+```js
+class RecordAlreadyExistsError extends Error {
+  // ...
+}
+
+if (userExists(user)) {
+  throw new RecordAlreadyExistsError("Already exists.");
+}
+```
+
 #### Rejected Promises must always be catched and at least logged
 
 Otherwise information might be lost.

--- a/js/error-handling.md
+++ b/js/error-handling.md
@@ -25,13 +25,33 @@ BAD
 class ExampleError extends Error {}
 ```
 
-#### Define meaningful error classes
+#### Objects need to be serialized in error messages
+
+GOOD
+
+```js
+throw new RecordAlreadyExistsError(JSON.stringify(user) + " already exists.");
+// OUTPUT => "user { ... } already exists."
+```
+
+BAD
+
+```js
+console.error(user + " already exists.");
+// OUTPUT => "[object Object] already exists."
+```
+
+#### Define reusable error classes, provide details as error message
 
 GOOD
 
 ```js
 class RecordAlreadyExistsError extends Error {
   // ...
+}
+
+if (userExists(user)) {
+  throw new RecordAlreadyExistsError(JSON.stringify(user) + " already exists.");
 }
 ```
 
@@ -41,31 +61,9 @@ BAD
 class UserError extends Error {
   // ...
 }
-```
-
-#### Pass additional, useful information along with the error message
-
-GOOD
-
-```js
-class RecordAlreadyExistsError extends Error {
-  // ...
-}
 
 if (userExists(user)) {
-  throw new RecordAlreadyExistsError(user + " already exists.");
-}
-```
-
-BAD
-
-```js
-class RecordAlreadyExistsError extends Error {
-  // ...
-}
-
-if (userExists(user)) {
-  throw new RecordAlreadyExistsError("Already exists.");
+  throw new UserError("Already exists.");
 }
 ```
 

--- a/node/file-structure-naming.md
+++ b/node/file-structure-naming.md
@@ -13,6 +13,7 @@
 .
 ├── app
 │   ├── errors
+│   │   └── record-already-exists-error.js
 │   ├── db
 │   │   └── user
 │   │       ├── user.js

--- a/node/file-structure-naming.md
+++ b/node/file-structure-naming.md
@@ -12,6 +12,7 @@
 ```
 .
 ├── app
+│   ├── errors
 │   ├── db
 │   │   └── user
 │   │       ├── user.js


### PR DESCRIPTION
Added an additional best practice to the JavaScript error-handling guide - discussed with @thisismydesign. Furthermore, extended the NodeJS example structure with the `errors` folder - contains the pre-made, custom error classes.

Discussed [**here**](https://gitlab.com/c-hive/firebase-paypal/merge_requests/3).