### PR TITLE
Styled components - naming convention

### DIFF
--- a/react/styling-and-css.md
+++ b/react/styling-and-css.md
@@ -141,7 +141,7 @@ export const buttonStyle = css`
 `;
 ```
 
-Styled components apply *UpperCamelCase* without the suffix.
+Styled components don't use the suffix.
 
 ```js
 // => Component.js

--- a/react/styling-and-css.md
+++ b/react/styling-and-css.md
@@ -146,7 +146,7 @@ Styled components apply *UpperCamelCase* without the suffix.
 ```js
 // => component.js
 import styled from "styled-components";
-import { buttonStyle } from "./component.style.js";
+import { buttonStyle } from "./component.style";
 
 const Button = styled.button`${buttonStyle}`;
 ```
@@ -168,12 +168,12 @@ const Button = styled.button`${buttonStyle}`;
 Header.js
 ```js
 import styled from 'styled-components';
-import { headerDivStyle } from './Header.style';
+import { headerStyle } from './Header.style';
 
 const header = () => {
-  const styledHeader = styled.div`${headerDivStyle};`;
+  const Header = styled.div`${headerStyle};`;
 
-  return <styledHeader />;
+  return <Header />;
 };
 
 export default header;
@@ -183,7 +183,7 @@ Header.style.js
 ```js
 import { css } from 'styled-components';
 
-export const headerDivStyle = css`
+export const headerStyle = css`
   margin: 0.5rem 1rem;
   width: 11rem;
   background: transparent;

--- a/react/styling-and-css.md
+++ b/react/styling-and-css.md
@@ -167,8 +167,8 @@ const Button = styled.button`${buttonStyle}`;
 
 Header.js
 ```js
-import styled from 'styled-components';
-import { headerStyle } from './Header.style';
+import styled from "styled-components";
+import { headerStyle } from "./Header.style";
 
 const header = () => {
   const Header = styled.div`${headerStyle}`;
@@ -181,7 +181,7 @@ export default header;
 
 Header.style.js
 ```js
-import { css } from 'styled-components';
+import { css } from "styled-components";
 
 export const headerStyle = css`
   margin: 0.5rem 1rem;

--- a/react/styling-and-css.md
+++ b/react/styling-and-css.md
@@ -171,7 +171,7 @@ import styled from 'styled-components';
 import { headerStyle } from './Header.style';
 
 const header = () => {
-  const Header = styled.div`${headerStyle};`;
+  const Header = styled.div`${headerStyle}`;
 
   return <Header />;
 };

--- a/react/styling-and-css.md
+++ b/react/styling-and-css.md
@@ -133,7 +133,7 @@ Component styles are declared in a separate `.styles.js` file using the [`css` h
 Elements within the style files use the `Style` suffix.
 
 ```js
-// => component.style.js
+// => Component.style.js
 import { css } from "styled-components";
 
 export const buttonStyle = css`
@@ -144,7 +144,7 @@ export const buttonStyle = css`
 Styled components apply *UpperCamelCase* without the suffix.
 
 ```js
-// => component.js
+// => Component.js
 import styled from "styled-components";
 import { buttonStyle } from "./component.style";
 

--- a/react/styling-and-css.md
+++ b/react/styling-and-css.md
@@ -128,6 +128,29 @@ Component styles are declared in a separate `.styles.js` file using the [`css` h
 
 [SMACSS categories](https://smacss.com/book/categorizing) provide a practical separation of concerns. Module and state categories are covered by the `component.style.js` pattern, however styles that reach accross components (whether because they are global or just affect many components) need a proper place. Place them in `src/common_styles` and use SMACSS catogires for grouping. Applies both to CSS and CSS-in-JS.
 
+#### Naming
+
+Elements within the style files use the `Style` suffix.
+
+```js
+// => component.style.js
+import { css } from "styled-components";
+
+export const buttonStyle = css`
+  // ...
+`;
+```
+
+Styled components apply *UpperCamelCase* without the suffix.
+
+```js
+// => component.js
+import styled from "styled-components";
+import { buttonStyle } from "./component.style.js";
+
+const Button = styled.button`${buttonStyle}`;
+```
+
 
 ## CSS-in-JS example
 


### PR DESCRIPTION
There's no relevant issue.

For some insights, see the referenced comments:
- [**#1**](https://github.com/c-hive/guides/pull/9#issuecomment-503500769),
- [**#2**](https://github.com/c-hive/guides/pull/9#issuecomment-503583930),
- [**#3**](https://github.com/c-hive/guides/pull/9#issuecomment-503683051).

Changes:
- extended the **Conventions** phase with **Naming**,
- added practical examples for both cases,
- updated **CSS-in-JS** examples accordingly.

It might be unnecessary to demonstrate examples in this phase as **CSS-in-JS** already does it. On the other hand, IMO it's a good practice to place the examples where they belong to.

What do you think?