### PR TITLE
Construct a better ReactJS structure

### DIFF
--- a/react/file-structure-naming.md
+++ b/react/file-structure-naming.md
@@ -21,6 +21,8 @@
 │   │   │   ├── App.js
 │   │   │   ├── App.test.js
 │   │   │   └── App.test.js.snap
+│   │   │   ├── helpers
+│   │   │   │   └── RSSParser.js
 │   │   └── Header
 │   │       ├── Header.css
 │   │       ├── Header.js
@@ -49,9 +51,11 @@
 - `src/utils`
   - Non-UI / non-component / utility features not tightly linked to the specific project (e.g. `Api`, `CorsProxy`)
 - `src/resources`
-  - Machine readable, hardcoded data (e.g. `ItemTypes`, json data files)
+  - Machine readable, hardcoded data (e.g. settings in a JSON file)
 - `src/common_styles`
   - style files applied to the whole project
+- `src/components/*/helpers`
+    - tightly coupled function(s) to a specific component
 
 ## Grouping
 

--- a/react/file-structure-naming.md
+++ b/react/file-structure-naming.md
@@ -27,8 +27,7 @@
 │   │   │   ├── Medium.test.js
 │   │   │   ├── Medium.spec.js.snap
 │   │   │   └── utils
-│   │   │   │   └── MediumUtils
-│   │   │   │   │   ├── MediumUtils.js
+│   │   │   │   ├── MediumUtils.js
 │   ├── errors
 │   │   └── custom-error-class.js
 │   └── utils

--- a/react/file-structure-naming.md
+++ b/react/file-structure-naming.md
@@ -17,15 +17,18 @@
 │   │   └── layout.css
 │   ├── components
 │   │   ├── App
-│   │   │   ├── App.css
 │   │   │   ├── App.js
+│   │   │   ├── App.style.js
 │   │   │   ├── App.test.js
-│   │   │   └── App.test.js.snap
-│   │   └── Header
-│   │       ├── Header.css
-│   │       ├── Header.js
-│   │       ├── Header.test.js
-│   │       └── Header.spec.js.snap
+│   │   │   ├── App.test.js.snap
+│   │   └── Medium
+│   │   │   ├── Medium.js
+│   │   │   ├── Medium.style.js
+│   │   │   ├── Medium.test.js
+│   │   │   ├── Medium.spec.js.snap
+│   │   │   └── utils
+│   │   │   │   └── MediumUtils
+│   │   │   │   │   ├── MediumUtils.js
 │   ├── errors
 │   │   └── custom-error-class.js
 │   └── utils
@@ -48,6 +51,8 @@
 ## Special folders
 
 - `src/components`
+- `src/components/*/utils`
+ - Tightly coupled function(s) to a specific component
 - `src/utils`
   - Non-UI / non-component / utility features not tightly linked to the specific project (e.g. `Api`, `CorsProxy`)
 - `src/resources`

--- a/react/file-structure-naming.md
+++ b/react/file-structure-naming.md
@@ -21,13 +21,13 @@
 │   │   │   ├── App.js
 │   │   │   ├── App.test.js
 │   │   │   └── App.test.js.snap
-│   │   │   ├── helpers
-│   │   │   │   └── RSSParser.js
 │   │   └── Header
 │   │       ├── Header.css
 │   │       ├── Header.js
 │   │       ├── Header.test.js
 │   │       └── Header.spec.js.snap
+│   ├── errors
+│   │   └── custom-error-class.js
 │   └── utils
 │       ├── testing
 │       │   └── TestHelpers.js
@@ -53,9 +53,9 @@
 - `src/resources`
   - Machine readable, hardcoded data (e.g. settings in a JSON file)
 - `src/common_styles`
-  - style files applied to the whole project
-- `src/components/*/helpers`
-    - tightly coupled function(s) to a specific component
+  - Style files applied to the whole project
+- `src/errors`
+    - Custom error objects
 
 ## Grouping
 


### PR DESCRIPTION
Some of our projects contain functions in the `utils` folder that are tightly coupled to a specific component and are no longer reusable in any way. This is a bad practice due to the intention of `utils`:

```
Non-UI / non-component / utility features not tightly linked to the specific project
```

We have therefore decided to extract the specific functions alongside the component they belong. I would propose naming it `helpers` but other suggestions are welcome.

Reference:
- https://medium.com/@Charles_Stover/optimal-file-structure-for-react-applications-f3e35ad0a145